### PR TITLE
Merge `can_eval` and check_eval 

### DIFF
--- a/docs/src/bot.md
+++ b/docs/src/bot.md
@@ -39,7 +39,7 @@ botconfig = BotConfig(
   os = ["linux", "windows", "macos"],  # operating systems for which to precompile
   version = [v"1.4.2", v"1.3.1"],      # supported Julia versions
   blacklist = ["SqEuclidean"],         # exclude functions (by name) that would be problematic if precompiled
-  exhaustive = false,                  # do not remove statements that fail to eval
+  check_eval = false,                  # do not remove statements that fail to eval
 )
 
 snoop_bot(

--- a/docs/src/bot.md
+++ b/docs/src/bot.md
@@ -39,7 +39,6 @@ botconfig = BotConfig(
   os = ["linux", "windows", "macos"],  # operating systems for which to precompile
   version = [v"1.4.2", v"1.3.1"],      # supported Julia versions
   blacklist = ["SqEuclidean"],         # exclude functions (by name) that would be problematic if precompiled
-  check_eval = false,                  # do not remove statements that fail to eval
 )
 
 snoop_bot(

--- a/src/bot.jl
+++ b/src/bot.jl
@@ -22,11 +22,9 @@ You may supply the following optional **keyword** arguments:
 
 - `blacklist` : A vector of of Strings (or RegExp) to remove some precompile statements
 
-- `check_eval`: passing `true` discards precompile statements that cannot be `eval`ed.
-  However, it slows down the processing stage.
-  Defaults to `false`. Use this feature if SnoopCompile benchmark or your CI fails.
-  This feature also prints the errors, which you can fix by `blacklist`ing the offending statements
-  and then disabling `check_eval` for future runs.
+- `check_eval`: By default, the bot discards the precompile statements that cannot be `eval`ed.
+
+In some cases, you may use the printed errors of this feature to `blacklist` the offending statements and then set `check_eval=false` for the future runs to increase the snooping performance.
 
 - `os`: A vector of of Strings (or RegExp) to support with precompile statements.
 
@@ -100,7 +98,7 @@ end
 function BotConfig(
     package_name::AbstractString;
     blacklist::AbstractVector = String[],
-    check_eval::Bool = false,
+    check_eval::Bool = true,
     os::Union{Vector{String}, Nothing} = nothing,
     else_os::Union{String, Nothing} = nothing,
     version::Union{Vector{<:Union{VersionNumber,String}}, Nothing} = nothing,

--- a/src/bot.jl
+++ b/src/bot.jl
@@ -22,11 +22,11 @@ You may supply the following optional **keyword** arguments:
 
 - `blacklist` : A vector of of Strings (or RegExp) to remove some precompile statements
 
-- `exhaustive`: passing `true` discards precompile statements that cannot be `eval`ed.
+- `check_eval`: passing `true` discards precompile statements that cannot be `eval`ed.
   However, it slows down the processing stage.
   Defaults to `false`. Use this feature if SnoopCompile benchmark or your CI fails.
   This feature also prints the errors, which you can fix by `blacklist`ing the offending statements
-  and then disabling `exhaustive` for future runs.
+  and then disabling `check_eval` for future runs.
 
 - `os`: A vector of of Strings (or RegExp) to support with precompile statements.
 
@@ -86,7 +86,7 @@ BotConfig("MatLang", os = ["linux", "windows"], version = [v"1.1", v"1.4.2"])
 struct BotConfig
     package_name::AbstractString
     blacklist::Vector{UStrings}
-    exhaustive::Bool
+    check_eval::Bool
     os::Union{Vector{String}, Nothing}
     else_os::Union{String, Nothing}
     version::Union{Vector{VersionNumber}, Nothing}
@@ -100,7 +100,7 @@ end
 function BotConfig(
     package_name::AbstractString;
     blacklist::AbstractVector = String[],
-    exhaustive::Bool = false,
+    check_eval::Bool = false,
     os::Union{Vector{String}, Nothing} = nothing,
     else_os::Union{String, Nothing} = nothing,
     version::Union{Vector{<:Union{VersionNumber,String}}, Nothing} = nothing,
@@ -118,7 +118,7 @@ function BotConfig(
         else_version = JuliaVersionNumber(else_version)
     end
 
-    return BotConfig(package_name, blacklist, exhaustive, os, else_os, version, else_version, GoodPath(package_path), GoodPath(precompiles_rootpath), subst, tmin)
+    return BotConfig(package_name, blacklist, check_eval, os, else_os, version, else_version, GoodPath(package_path), GoodPath(precompiles_rootpath), subst, tmin)
 end
 
 include("bot/botutils.jl")

--- a/src/bot.jl
+++ b/src/bot.jl
@@ -22,10 +22,6 @@ You may supply the following optional **keyword** arguments:
 
 - `blacklist` : A vector of of Strings (or RegExp) to remove some precompile statements
 
-- `check_eval`: By default, the bot discards the precompile statements that cannot be `eval`ed.
-
-In some cases, you may use the printed errors of this feature to `blacklist` the offending statements and then set `check_eval=false` for the future runs to increase the snooping performance.
-
 - `os`: A vector of of Strings (or RegExp) to support with precompile statements.
 
 Example: `os = ["windows", "linux"]`
@@ -59,6 +55,11 @@ Example: `else_version = v"1.4.2"`
 
 - `tmin`: Methods that take less time than `tmin` to be inferred will not be added to the
   precompile statements. Defaults to 0.
+
+- `check_eval`: By default, the bot discards the precompile statements that cannot be `eval`ed.
+
+In rare cases, you may want to do this manually by using the printed errors of this feature to `blacklist` the offending statements and then set `check_eval=false` for the future runs to increase the snooping performance.
+
 
 # Example
 ```julia

--- a/src/bot/snoop_bot.jl
+++ b/src/bot/snoop_bot.jl
@@ -27,7 +27,7 @@ end
 function _snoop_bot_expr(config::BotConfig, snoop_script, test_modul::Module; snoop_mode::Symbol)
     package_name = config.package_name
     blacklist = config.blacklist
-    exhaustive = config.exhaustive
+    check_eval = config.check_eval
     os = config.os
     else_os = config.else_os
     version = config.version
@@ -97,7 +97,7 @@ function _snoop_bot_expr(config::BotConfig, snoop_script, test_modul::Module; sn
         ################################################################
         @info "Processsing the generated precompile signatures"
         ### Parse the compiles and generate precompilation scripts
-        pc = SnoopCompile.parcel(data, subst = $subst, blacklist = $blacklist, exhaustive = $exhaustive)
+        pc = SnoopCompile.parcel(data, subst = $subst, blacklist = $blacklist, check_eval = $check_eval)
         if !haskey(pc, packageSym)
             @error "no precompile signature is found for $($package_name). Don't load the package before snooping. Restart your Julia session."
         end

--- a/src/parcel_snoopc.jl
+++ b/src/parcel_snoopc.jl
@@ -149,7 +149,7 @@ function parcel(calls::AbstractVector{String};
     # for mod in keys(pc)
     #     # check_eval remover
     #     if check_eval
-    #         pc[mod] = exhaustive_remover!(pc[mod], sym_module[mod])
+    #         pc[mod] = remove_if_not_eval!(pc[mod], sym_module[mod])
     #     end
     # end
     return pc
@@ -167,4 +167,42 @@ function format_userimg(calls; subst=Vector{Pair{String, String}}(), blacklist=S
         push!(pc, prefix * "precompile($pcstring)")
     end
     return pc
+end
+
+# TODO Make this work with snoopc:
+
+"""
+    remove_if_not_eval!(pcstatements, modul::Module)
+
+Removes everything statement in `pcstatements` can't be `eval`ed in `modul`.
+
+# Example
+
+```jldoctest; setup=:(using SnoopCompile), filter=r":\\d\\d\\d"
+julia> pcstatements = ["precompile(sum, (Vector{Int},))", "precompile(sum, (CustomVector{Int},))"];
+
+julia> SnoopCompile.remove_if_not_eval!(pcstatements, Base)
+┌ Warning: Faulty precompile statement: precompile(sum, (CustomVector{Int},))
+│   exception = UndefVarError: CustomVector not defined
+└ @ Base precompile_Base.jl:375
+1-element Array{String,1}:
+ "precompile(sum, (Vector{Int},))"
+```
+"""
+function remove_if_not_eval!(pcstatements, modul::Module)
+    todelete = Set{eltype(pcstatements)}()
+    for line in pcstatements
+        try
+            if modul === Core
+                #https://github.com/timholy/SnoopCompile.jl/issues/76
+                Core.eval(Main, Meta.parse(line))
+            else
+                Core.eval(modul, Meta.parse(line))
+            end
+        catch e
+            @warn("Faulty precompile statement: $line", exception = e, _module = modul, _file = "precompile_$modul.jl")
+            push!(todelete, line)
+        end
+    end
+    return setdiff!(pcstatements, todelete)
 end

--- a/src/parcel_snoopc.jl
+++ b/src/parcel_snoopc.jl
@@ -122,7 +122,7 @@ function parcel(calls::AbstractVector{String};
     subst=Vector{Pair{String, String}}(),
     blacklist=String[],
     remove_blacklist::Bool = true,
-    exhaustive::Bool = false)
+    check_eval::Bool = false)
     
     pc = Dict{Symbol, Vector{String}}()
     
@@ -147,8 +147,8 @@ function parcel(calls::AbstractVector{String};
 
     # TODO
     # for mod in keys(pc)
-    #     # exhaustive remover
-    #     if exhaustive
+    #     # check_eval remover
+    #     if check_eval
     #         pc[mod] = exhaustive_remover!(pc[mod], sym_module[mod])
     #     end
     # end

--- a/src/parcel_snoopi.jl
+++ b/src/parcel_snoopi.jl
@@ -205,7 +205,7 @@ function parcel(tinf::AbstractVector{Tuple{Float64, Core.MethodInstance}};
     subst = Vector{Pair{String, String}}(),
     blacklist = String[],
     remove_blacklist::Bool = true,
-    exhaustive::Bool = false)
+    check_eval::Bool = false)
 
     pc = Dict{Symbol, Set{String}}()         # output
     modgens = Dict{Module, Vector{Method}}() # methods with generators in a module
@@ -317,8 +317,8 @@ function parcel(tinf::AbstractVector{Tuple{Float64, Core.MethodInstance}};
         if remove_blacklist
             pc[mod] = blacklist_remover!(pc[mod], blacklist)
         end
-        # exhaustive remover
-        if exhaustive
+        # check_eval remover
+        if check_eval
             pc[mod] = exhaustive_remover!(pc[mod], sym_module[mod])
         end
     end

--- a/src/parcel_snoopi.jl
+++ b/src/parcel_snoopi.jl
@@ -128,7 +128,12 @@ end
 function can_eval(mod::Module, str::AbstractString)
     try
         ex = Meta.parse(str)
-        Core.eval(mod, ex)
+        if mod === Core
+            #https://github.com/timholy/SnoopCompile.jl/issues/76
+            Core.eval(Main, ex)
+        else
+            Core.eval(mod, ex)
+        end
     catch
         return false
     end


### PR DESCRIPTION
@timholy This is based on the discussion here: https://github.com/aminya/SnoopCompile.jl/pull/1#discussion_r438825332

- I merged `can_eval` and `exhaustive_remover` to prevent double evaluation (huge performance gain).
- I used the `check_eval` option (renamed from `exhaustive`) to allow the user to set this off. The default must be true to avoid breakage.